### PR TITLE
Change Launch item to use full path to Python

### DIFF
--- a/com.github.offset.logout.plist
+++ b/com.github.offset.logout.plist
@@ -10,6 +10,7 @@
   </array>
   <key>ProgramArguments</key>
   <array>
+    <string>/usr/bin/python</string>
     <string>/usr/local/offset/offset</string>
     <string>--logout</string>
   </array>


### PR DESCRIPTION
This changes mirrors change done to Outset. Will allow Offset to be whitelisted in a Privacy Preferences Policy Control Profile.

[Referenced Outset change](https://github.com/chilcote/outset/pull/59/commits/36c158e50622b8b68743a26eefb82aa2044b529d)